### PR TITLE
add the getShowTitles functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ addic7edApi.search('South Park', 19, 6).then(function (subtitlesList) {
         });
     }
 });
+addic7edApi.getShowTitles().then(function(showTitlesList){
+    console.log('All show titles available:', showTitlesList);
+});
 ```
 
 
@@ -64,3 +67,10 @@ Download and save a subtitles file.
 
 Returns a promise which is resolved when the file is written.
 
+### addic7edApi.getShowTitles()
+
+Return a list of all available show titles.
+
+#### Return value
+
+Returns a promise which is resolved when the get operation is complete. This promise returns a list of show titles.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
     search:   require('./lib/search'),
-    download: require('./lib/download')
+    download: require('./lib/download'),
+    getShowTitles: require('./lib/getShowTitles')
 };

--- a/lib/getShowTitles.js
+++ b/lib/getShowTitles.js
@@ -1,0 +1,34 @@
+var request = require('request-promise-native'),
+    helpers = require('./helpers');
+
+function getShowTitles () {
+    var headers = {
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+    };
+
+    return request({
+        uri:     helpers.addic7edURL + '/shows.php',
+        headers: headers
+    }).then(function (body) {
+        // Find all show titles
+        // -------------------------------------------------
+        var regexp   = /<a href="\/show\/\d*">([^<]*)<\/a>/gm;            
+        let match, 
+        showTitles = [];
+        while ((match = regexp.exec(body)) !== null) {
+            // This is necessary to avoid infinite loops with zero-width matches
+            if (match.index === regexp.lastIndex) {
+                regexp.lastIndex++;
+            }
+            showTitles.push(match[1]);            
+        }
+
+        return showTitles;
+    }).catch(getShowTitlesError);
+}
+
+function getShowTitlesError (err) {
+    return console.log('[GetShowTitlesError] Addic7ed.com error', err.statusCode, err.options && err.options.qs.search);
+}
+
+module.exports = getShowTitles;


### PR DESCRIPTION
getShowTitles returns all showtitles, pulled from [the shows page](http://www.addic7ed.com/shows.php).

suggested usage:
Show titles in file names do not always match with those used by addic7ed.
Therefore I get all known showtitles once and compare them using [string-similarity].(https://www.npmjs.com/package/string-similarity.)
getShowTitles was something I wanted to share with the community :smile: 